### PR TITLE
fix: page shake due to scrollbar

### DIFF
--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  scrollbar-gutter: stable;
+}
+
 .container {
   @apply max-w-screen-lg;
   @apply px-5 lg:px-16;


### PR DESCRIPTION
The presence or absence of scrollbar causes shaking when switching pages.

It occurs, for example, when switching from English post to Chinese post in home.

Use [`scrollbar-gutter: stable;`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter) to keep the space that always occupies the scrollbar size.